### PR TITLE
Fix Spawnmenu open error with Bots

### DIFF
--- a/lua/autorun/client/cl_nadmodpp.lua
+++ b/lua/autorun/client/cl_nadmodpp.lua
@@ -198,28 +198,30 @@ function NADMOD.AdminPanel(Panel, runByNetReceive)
 	Panel:Button("Cleanup World Ropes", "nadmod_cleanworldropes")
 end
 
+local metaply = FindMetaTable("Player")
+
 -- Wrapper function as Bots return nothing clientside for their SteamID64
-function SteamID64bot( ply )
-	if( not IsValid( ply ) ) then return end
-	if ply:IsBot() then
+function metaply:SteamID64bot()
+	if( not IsValid( self ) ) then return end
+	if self:IsBot() then
 		-- Calculate Bot's SteamID64 according to gmod wiki
-		return  90071996842377216 + tonumber( string.sub( ply:Nick(), 4) )
+		return  90071996842377216 + tonumber( string.sub( self:Nick(), 4) )
 	else
-		return ply:SteamID64()
+		return self:SteamID64()
 	end
 end
 
 net.Receive("nadmod_ppfriends",function(len)
 	NADMOD.Friends = net.ReadTable()
 	for _,tar in pairs(player.GetAll()) do
-		CreateClientConVar("npp_friend_"..SteamID64bot(tar),NADMOD.Friends[tar:SteamID()] and "1" or "0", false, false)
-		RunConsoleCommand("npp_friend_"..SteamID64bot(tar),NADMOD.Friends[tar:SteamID()] and "1" or "0")
+		CreateClientConVar("npp_friend_"..tar:SteamID64bot(),NADMOD.Friends[tar:SteamID()] and "1" or "0", false, false)
+		RunConsoleCommand("npp_friend_"..tar:SteamID64bot(),NADMOD.Friends[tar:SteamID()] and "1" or "0")
 	end
 end)
 
 concommand.Add("npp_applyfriends",function(ply,cmd,args)
 	for _,tar in pairs(player.GetAll()) do
-		NADMOD.Friends[tar:SteamID()] = GetConVar("npp_friend_"..SteamID64bot(tar)):GetBool()
+		NADMOD.Friends[tar:SteamID()] = GetConVar("npp_friend_"..tar:SteamID64bot()):GetBool()
 	end
 	net.Start("nadmod_ppfriends")
 		net.WriteTable(NADMOD.Friends)
@@ -246,7 +248,7 @@ function NADMOD.ClientPanel(Panel)
 	else
 		for _, tar in pairs(Players) do
 			if(IsValid(tar) and tar != LocalPlayer()) then
-				Panel:CheckBox(tar:Nick(), "npp_friend_"..SteamID64bot(tar))
+				Panel:CheckBox(tar:Nick(), "npp_friend_"..tar:SteamID64bot())
 			end
 		end
 		Panel:Button("Apply Friends", "npp_applyfriends")
@@ -278,7 +280,6 @@ end)
 
 CPPI = {}
 local metaent = FindMetaTable("Entity")
-local metaply = FindMetaTable("Player")
 
 function CPPI:GetName() return "Nadmod Prop Protection" end
 function CPPI:GetVersion() return "" end

--- a/lua/autorun/client/cl_nadmodpp.lua
+++ b/lua/autorun/client/cl_nadmodpp.lua
@@ -199,6 +199,7 @@ function NADMOD.AdminPanel(Panel, runByNetReceive)
 end
 
 local metaply = FindMetaTable("Player")
+local metaent = FindMetaTable("Entity")
 
 -- Wrapper function as Bots return nothing clientside for their SteamID64
 function metaply:SteamID64bot()

--- a/lua/autorun/client/cl_nadmodpp.lua
+++ b/lua/autorun/client/cl_nadmodpp.lua
@@ -280,7 +280,6 @@ net.Receive("nadmod_notify", function(len)
 end)
 
 CPPI = {}
-local metaent = FindMetaTable("Entity")
 
 function CPPI:GetName() return "Nadmod Prop Protection" end
 function CPPI:GetVersion() return "" end

--- a/lua/autorun/client/cl_nadmodpp.lua
+++ b/lua/autorun/client/cl_nadmodpp.lua
@@ -200,7 +200,7 @@ end
 
 net.Receive("nadmod_ppfriends",function(len)
 	NADMOD.Friends = net.ReadTable()
-	for _,tar in pairs(player.GetAll()) do
+	for _,tar in pairs(player.GetHumans()) do
 		CreateClientConVar("npp_friend_"..tar:SteamID64(),NADMOD.Friends[tar:SteamID()] and "1" or "0", false, false)
 		RunConsoleCommand("npp_friend_"..tar:SteamID64(),NADMOD.Friends[tar:SteamID()] and "1" or "0")
 	end

--- a/lua/autorun/client/cl_nadmodpp.lua
+++ b/lua/autorun/client/cl_nadmodpp.lua
@@ -206,7 +206,7 @@ function metaply:SteamID64bot()
 	if( not IsValid( self ) ) then return end
 	if self:IsBot() then
 		-- Calculate Bot's SteamID64 according to gmod wiki
-		return  90071996842377216 + tonumber( string.sub( self:Nick(), 4) )
+		return  ( 90071996842377216 + tonumber( string.sub( self:Nick(), 4) ) -1 )
 	else
 		return self:SteamID64()
 	end

--- a/lua/autorun/client/cl_nadmodpp.lua
+++ b/lua/autorun/client/cl_nadmodpp.lua
@@ -198,17 +198,28 @@ function NADMOD.AdminPanel(Panel, runByNetReceive)
 	Panel:Button("Cleanup World Ropes", "nadmod_cleanworldropes")
 end
 
+-- Wrapper function as Bots return nothing clientside for their SteamID64
+function SteamID64bot( ply )
+	if( not IsValid( ply ) ) then return end
+	if ply:IsBot() then
+		-- Calculate Bot's SteamID64 according to gmod wiki
+		return  90071996842377216 + tonumber( string.sub( ply:Nick(), 4) )
+	else
+		return ply:SteamID64()
+	end
+end
+
 net.Receive("nadmod_ppfriends",function(len)
 	NADMOD.Friends = net.ReadTable()
-	for _,tar in pairs(player.GetHumans()) do
-		CreateClientConVar("npp_friend_"..tar:SteamID64(),NADMOD.Friends[tar:SteamID()] and "1" or "0", false, false)
-		RunConsoleCommand("npp_friend_"..tar:SteamID64(),NADMOD.Friends[tar:SteamID()] and "1" or "0")
+	for _,tar in pairs(player.GetAll()) do
+		CreateClientConVar("npp_friend_"..SteamID64bot(tar),NADMOD.Friends[tar:SteamID()] and "1" or "0", false, false)
+		RunConsoleCommand("npp_friend_"..SteamID64bot(tar),NADMOD.Friends[tar:SteamID()] and "1" or "0")
 	end
 end)
 
 concommand.Add("npp_applyfriends",function(ply,cmd,args)
 	for _,tar in pairs(player.GetAll()) do
-		NADMOD.Friends[tar:SteamID()] = GetConVar("npp_friend_"..tar:SteamID64()):GetBool()
+		NADMOD.Friends[tar:SteamID()] = GetConVar("npp_friend_"..SteamID64bot(tar)):GetBool()
 	end
 	net.Start("nadmod_ppfriends")
 		net.WriteTable(NADMOD.Friends)
@@ -235,7 +246,7 @@ function NADMOD.ClientPanel(Panel)
 	else
 		for _, tar in pairs(Players) do
 			if(IsValid(tar) and tar != LocalPlayer()) then
-				Panel:CheckBox(tar:Nick(), "npp_friend_"..tar:SteamID64())
+				Panel:CheckBox(tar:Nick(), "npp_friend_"..SteamID64bot(tar))
 			end
 		end
 		Panel:Button("Apply Friends", "npp_applyfriends")


### PR DESCRIPTION
Issue was the use of SteamID64() clientside with bots returns nothing
unlike serverside where it returns the ID as expected.

Have created a wrapper function for SteamID64 (SteamID64bot) that calculates the correct ID for Bots clientside and returns as normal.
For anything other than bots it calls the regular SteamID64()